### PR TITLE
Update JSON Workflow

### DIFF
--- a/.github/scripts/update_availprofiles.py
+++ b/.github/scripts/update_availprofiles.py
@@ -23,7 +23,7 @@ def get_profiles_data():
                         "ProfileICAO": data.get("ProfileICAO", ""),
                         "Scenery": data.get("Scenery", ""),
                         "Creator": data.get("Creator", ""),
-                        "Version": data.get("Version", 0),
+                        "Version": str(data.get("Version", "0")),
                         "FileNames": list(file_names)
                     })
     return profiles_data


### PR DESCRIPTION
Fixes GH Action for updating `availprofiles.json`.

- Version Number from `profile.json` will now always be a string and converted to `Version` in the backend.
